### PR TITLE
fix(modal): make ReportModal scrollable with max-height and overflow

### DIFF
--- a/src/components/ReportModal.tsx
+++ b/src/components/ReportModal.tsx
@@ -84,7 +84,7 @@ export const ReportModal: React.FC<ReportModalProps> = ({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between p-6 border-b">
           <div className="flex items-center space-x-2">
             <Flag className="text-red-600" size={20} />


### PR DESCRIPTION
 closes the Issue related to #10 
Solution:

- Added `max-h-[90vh]` to limit modal height relative to viewport
- Added `overflow-y-auto` to make modal content scrollable if it exceeds height
- Improves accessibility and responsiveness of the modal dialog

<img width="1623" height="949" alt="image" src="https://github.com/user-attachments/assets/fc8f2b0e-9fcb-489f-b28f-62668289fb2f" />


